### PR TITLE
Add group mailbox access

### DIFF
--- a/EWSEditor/Forms/FolderTreeForm.cs
+++ b/EWSEditor/Forms/FolderTreeForm.cs
@@ -1587,7 +1587,22 @@ namespace EWSEditor.Forms
 
                 if (res == DialogResult.Yes)
                 {
-                    FolderId oNewFodler = new FolderId(WellKnownFolderName.Root);
+                    FolderId oNewFodler;
+
+                    // if there is an anchor mailbox specified, use this for the root
+					// folder so that we open anchor mailbox folder tree. If the anchor mailbox
+					// is a group mailbox then this will display the group mailbox.
+                    string addr = service.HttpHeaders["X-AnchorMailbox"];
+                    if (!string.IsNullOrEmpty(addr))
+                    {
+                        Mailbox mailbox = new Mailbox(addr);
+                        oNewFodler = new FolderId(WellKnownFolderName.Root, mailbox);
+                    }
+                    else
+                    {
+                        oNewFodler = new FolderId(WellKnownFolderName.Root);
+                    }
+					
                     this.AddRootFolderToTreeView(
                         service,
                         oAppSettings,

--- a/EWSEditor/Forms/FolderTreeForm.cs
+++ b/EWSEditor/Forms/FolderTreeForm.cs
@@ -1587,22 +1587,23 @@ namespace EWSEditor.Forms
 
                 if (res == DialogResult.Yes)
                 {
-                    FolderId oNewFodler;
+                    FolderId oNewFodler = null;
 
-                    // if there is an anchor mailbox specified, use this for the root
-					// folder so that we open anchor mailbox folder tree. If the anchor mailbox
-					// is a group mailbox then this will display the group mailbox.
-                    string addr = service.HttpHeaders["X-AnchorMailbox"];
-                    if (!string.IsNullOrEmpty(addr))
+                    if (service.HttpHeaders.ContainsKey("X-AnchorMailbox"))
                     {
-                        Mailbox mailbox = new Mailbox(addr);
-                        oNewFodler = new FolderId(WellKnownFolderName.Root, mailbox);
+                        string addr = service.HttpHeaders["X-AnchorMailbox"];
+                        if (!string.IsNullOrEmpty(addr))
+                        {
+                            Mailbox mailbox = new Mailbox(addr);
+                            oNewFodler = new FolderId(WellKnownFolderName.Root, mailbox);
+                        }
                     }
-                    else
+                    
+                    if (oNewFodler == null)
                     {
                         oNewFodler = new FolderId(WellKnownFolderName.Root);
                     }
-					
+
                     this.AddRootFolderToTreeView(
                         service,
                         oAppSettings,


### PR DESCRIPTION
Add functionality for Office 365 Group Mailboxes. If you put the group mailbox address in the Anchor Header, the tree view will display the Group Mailbox.