### PR TITLE
Support Exchange Server 2019 since it required .net framework 4.6 or later

### DIFF
--- a/EWSEditor/App.config
+++ b/EWSEditor/App.config
@@ -149,7 +149,7 @@
   </appSettings>
   <startup>
     
-  <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.1"/></startup>
+  <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6"/></startup>
   <system.serviceModel>
     <bindings/>
   </system.serviceModel>

--- a/EWSEditor/EWSEditor.csproj
+++ b/EWSEditor/EWSEditor.csproj
@@ -20,7 +20,7 @@
     <SccAuxPath>SAK</SccAuxPath>
     <SccProvider>SAK</SccProvider>
     <ApplicationIcon>Resources\EWSEditor2.ico</ApplicationIcon>
-    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <StartupObject>EWSEditor.Program</StartupObject>
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <TargetFrameworkProfile>

--- a/EWSEditor/packages.config
+++ b/EWSEditor/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net451" />
-  <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net451" />
-  <package id="Microsoft.IdentityModel.Clients.ActiveDirectory" version="3.19.4" targetFramework="net451" />
-  <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net451" />
-  <package id="System.Management.Automation.dll" version="10.0.10586.0" targetFramework="net451" />
+  <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net46" />
+  <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net46" />
+  <package id="Microsoft.IdentityModel.Clients.ActiveDirectory" version="3.19.4" targetFramework="net46" />
+  <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net46" />
+  <package id="System.Management.Automation.dll" version="10.0.10586.0" targetFramework="net46" />
 </packages>


### PR DESCRIPTION
Exchange Server 2019 required .net framework version at least v4.6. The ExchangeService connection will failed while .net framework version is 4.5.2 or older.