### PR TITLE
Use the correct property to configure the UserAgent Header.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@
 /EWSEditor.zip
 /EWSEditor Beta 1.19.zip
 /EwsEditor 1.18 plus new stuff.zip
+*.suo
+/.vs

--- a/EWSEditor/Common/EwsProxyFactory.cs
+++ b/EWSEditor/Common/EwsProxyFactory.cs
@@ -318,9 +318,11 @@ namespace EWSEditor.Exchange
         public static void CreateHttpWebRequest(ref HttpWebRequest oRequest)
         {
             HttpWebRequest oHttpWebRequest = (HttpWebRequest)WebRequest.Create(EwsUrl);
-             
+
             if (UserAgent.Length != 0)
-                oHttpWebRequest.Headers.Add("User-Agent", UserAgent);
+            {
+                oHttpWebRequest.UserAgent = UserAgent;
+            }
 
             oHttpWebRequest.Method = "POST";
             oHttpWebRequest.ContentType = "text/xml";


### PR DESCRIPTION
The API doesn't allow to add User-Agent header with HttpWebRequest.Headers.Add("User-Agent", UserAgent);, so change it to the correct one.