### PR TITLE
Update FolderTreeForm.cs

### DIFF
--- a/EWSEditor/Forms/FolderTreeForm.cs
+++ b/EWSEditor/Forms/FolderTreeForm.cs
@@ -1702,7 +1702,8 @@ namespace EWSEditor.Forms
             // The node image shouldn't change when selected
             newNode.SelectedImageIndex = newNode.ImageIndex;
 
-            if (folder.ChildFolderCount > 0)
+            // ChildFolderCount count is no longer returned for SearchFolders
+            if (typeof(SearchFolder) != folder.GetType() && folder.ChildFolderCount > 0)
             {
                 newNode.Nodes.Add("[PLACEHOLDER]");
             }


### PR DESCRIPTION
Searchfolders were causing the logic of inspecting the ChildFolderCount property to throw an exception when you're trying to add another mailbox's root folder that you have access to.  Apparently, Exchange must've stopped returning the ChildFolderCount in this scenario